### PR TITLE
WIP: Addition of optional network interface parameterization to MulticastService

### DIFF
--- a/src/MulticastService.cs
+++ b/src/MulticastService.cs
@@ -160,14 +160,14 @@ namespace Makaretu.Dns
         /// <summary>
         /// Finds the first network interface that has a matching unicast address-
         /// </summary>
-        /// <param name="addressPattern">A part of an IPv4/IPv6 address on the network interface.</param>
+        /// <param name="addressPattern">Full, or beginning of an IPv4/IPv6 address on the network interface.</param>
         /// <returns>a matching interface or null</returns>
         public static NetworkInterface GetNetworkInterfaceFromPattern(string addressPattern)
         {
             foreach (NetworkInterface nic in GetNetworkInterfaces())
             {
                 var unicastAddresses = nic.GetIPProperties().UnicastAddresses;
-                if (unicastAddresses.Any(ua => ua.Address.ToString().Contains(addressPattern)))
+                if (unicastAddresses.Any(ua => ua.Address.ToString().StartsWith(addressPattern)))
                 {
                     return nic;
                 }

--- a/test/MulticastServiceTest.cs
+++ b/test/MulticastServiceTest.cs
@@ -286,7 +286,9 @@ namespace Makaretu.Dns
             foreach (var address in addresses)
             {
                 string pattern = address.ToString();
-                var nic = MulticastService.GetNetworkInterfaceFromPattern(pattern);
+                if (pattern.Contains('.'))
+                    pattern = pattern.Substring(0, pattern.LastIndexOf('.')) + ".0/24";
+                var nic = MulticastService.GetNetworkInterfaceFromCIDR(pattern);
                 Assert.IsNotNull(nic);
             }
         }

--- a/test/MulticastServiceTest.cs
+++ b/test/MulticastServiceTest.cs
@@ -30,6 +30,26 @@ namespace Makaretu.Dns
             mdns.Stop();
         }
 
+        /// <summary>
+        /// Tests the create/start/stop of the MulticastService for every available IP address.
+        /// </summary>
+        [TestMethod]
+        public void StartStop_SingleInterface()
+        {
+            var addresses = MulticastService.GetIPAddresses().ToArray();
+            foreach (var address in addresses)
+            {
+                string pattern = address.ToString();
+                if (pattern.Contains('.'))
+                    pattern = pattern.Substring(0, pattern.LastIndexOf('.')) + ".0/24";
+                var nic = MulticastService.GetNetworkInterfaceFromCIDR(pattern);
+                var mdns = new MulticastService(nic);
+                Assert.IsTrue(mdns.IsUsingSingleInterface);
+                mdns.Start();
+                mdns.Stop();
+            }
+        }
+
         [TestMethod]
         public void SendQuery()
         {
@@ -277,7 +297,6 @@ namespace Makaretu.Dns
             var addresses = MulticastService.GetIPAddresses().ToArray();
             Assert.AreNotEqual(0, addresses.Length);
         }
-
 
         [TestMethod]
         public void NicFromPattern()

--- a/test/MulticastServiceTest.cs
+++ b/test/MulticastServiceTest.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace Makaretu.Dns
 {
-    
+
     [TestClass]
     public class MulticastServiceTest
     {
@@ -39,7 +39,7 @@ namespace Makaretu.Dns
 
             var mdns = new MulticastService();
             mdns.NetworkInterfaceDiscovered += (s, e) => ready.Set();
-            mdns.QueryReceived += (s, e) => 
+            mdns.QueryReceived += (s, e) =>
             {
                 msg = e.Message;
                 done.Set();
@@ -276,6 +276,19 @@ namespace Makaretu.Dns
         {
             var addresses = MulticastService.GetIPAddresses().ToArray();
             Assert.AreNotEqual(0, addresses.Length);
+        }
+
+
+        [TestMethod]
+        public void NicFromPattern()
+        {
+            var addresses = MulticastService.GetIPAddresses().ToArray();
+            foreach (var address in addresses)
+            {
+                string pattern = address.ToString();
+                var nic = MulticastService.GetNetworkInterfaceFromPattern(pattern);
+                Assert.IsNotNull(nic);
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
This is work in progress.

My goal is to introduce an optional parameter `NetworkInterface desiredInterface` that can be passed to `MulticastService.Start` to restrict Send/Receive operations to a specific network interface.

By specifying a network interface, the network interface discovery mechanism will be skipped entirely.

Changes so far:
+ [x] I introduced a static method `GetNetworkInterfaceFromPattern` that can be used to identify a network interface froma  (partial) IP address.
+ [x] with `RestrictToNetworkInterface`, the socket options on a `UdpClient` are set to limit it to a specific interface
+ [x] creation of the `sender` was refactored into its own method `RecreateSender`
+ [x] `Listen` was renamed to `RecreateReceiver`

Whenever `knownNics.Count == 1`, the `RestrictToNetworkInterface` is used to explicitly limit the sender/receiver `UdpClient` to this single interface.