### PR TITLE
MulticastService with multiple NICs

### DIFF
--- a/src/MessageEventArgs.cs
+++ b/src/MessageEventArgs.cs
@@ -1,7 +1,5 @@
-﻿using Makaretu.Dns;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System;
+using System.Net;
 
 namespace Makaretu.Dns
 {
@@ -18,6 +16,14 @@ namespace Makaretu.Dns
         ///   The received message.
         /// </value>
         public Message Message { get; set; }
+
+        /// <summary>
+        ///   The DNS message sender endpoint.
+        /// </summary>
+        /// <value>
+        ///   The endpoint from the message was received.
+        /// </value>
+        public IPEndPoint RemoteEndPoint { get; set; }
     }
 }
 

--- a/src/MulticastUdpListener.cs
+++ b/src/MulticastUdpListener.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+namespace Makaretu.Dns
+{
+    class MulticastUdpListener : IDisposable
+    {
+        public static readonly bool IP6;
+
+        private readonly IPEndPoint multicastEndpoint;
+
+        UdpClient receiver;
+        ConcurrentDictionary<IPAddress, UdpClient> senders = new ConcurrentDictionary<IPAddress, UdpClient>();
+
+        static MulticastUdpListener()
+        {
+            if (Socket.OSSupportsIPv4)
+                IP6 = false;
+            else if (Socket.OSSupportsIPv6)
+                IP6 = true;
+            else
+                throw new InvalidOperationException("No OS support for IPv4 nor IPv6");
+        }
+
+        public MulticastUdpListener(IPEndPoint multicastEndpoint, IEnumerable<NetworkInterface> nics)
+        {
+            this.multicastEndpoint = multicastEndpoint;
+
+            receiver = new UdpClient(multicastEndpoint.AddressFamily);
+
+            receiver.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+            receiver.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ExclusiveAddressUse, false);
+
+            receiver.Client.Bind(new IPEndPoint(IP6 ? IPAddress.IPv6Any : IPAddress.Any, multicastEndpoint.Port));
+
+            foreach (var address in nics.SelectMany(GetNetworkInterfaceLocalAddresses))
+            {
+                try
+                {
+                    receiver.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, new MulticastOption(multicastEndpoint.Address, address));
+
+                    var sender = new UdpClient(multicastEndpoint.AddressFamily);
+
+                    sender.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                    sender.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ExclusiveAddressUse, false);
+
+                    sender.Client.Bind(new IPEndPoint(address, multicastEndpoint.Port));
+
+                    sender.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, new MulticastOption(multicastEndpoint.Address));
+                    sender.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastLoopback, true);
+
+                    senders.TryAdd(address, sender);
+                }
+                catch (SocketException ex) when (ex.ErrorCode == (int)SocketError.AddressNotAvailable)
+                {
+                    // VPN NetworkInterfaces
+                }
+            }
+        }
+
+        public void SendAsync(byte[] message)
+        {
+            senders.ToList().ForEach(x => x.Value.SendAsync(message, message.Length, multicastEndpoint));
+        }
+
+        public void ListenAsync(Action<UdpReceiveResult> callback)
+        {
+            Task.Run(async () =>
+            {
+                try
+                {
+                    var result = await receiver.ReceiveAsync().ConfigureAwait(false);
+
+                    ListenAsync(callback);
+
+                    new Task(() => callback(result)).Start();
+                }
+                catch (ObjectDisposedException)
+                {
+                    return;
+                }
+            });
+        }
+
+        IEnumerable<IPAddress> GetNetworkInterfaceLocalAddresses(NetworkInterface nic)
+        {
+            return nic.GetIPProperties().UnicastAddresses
+                .Select(x => x.Address)
+                .Where(x => x.AddressFamily == (IP6 ? AddressFamily.InterNetworkV6 : AddressFamily.InterNetwork));
+        }
+
+        #region IDisposable Support
+
+        private bool disposedValue = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    receiver?.Dispose();
+
+                    foreach (var address in senders.Keys)
+                    {
+                        if (senders.TryRemove(address, out var sender))
+                        {
+                            sender.Dispose();
+                        }
+                    }
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        ~MulticastUdpListener()
+        {
+            Dispose(false);
+        }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        #endregion
+    }
+}

--- a/src/ServiceDiscovery.cs
+++ b/src/ServiceDiscovery.cs
@@ -1,9 +1,8 @@
-﻿using Common.Logging;
-using Makaretu.Dns.Resolving;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
+using Common.Logging;
+using Makaretu.Dns.Resolving;
 
 namespace Makaretu.Dns
 {
@@ -80,7 +79,8 @@ namespace Makaretu.Dns
         /// <value>
         ///   Is used to answer questions.
         /// </value>
-        public NameServer NameServer { get; } = new NameServer {
+        public NameServer NameServer { get; } = new NameServer
+        {
             Catalog = new Catalog(),
             AnswerAllQuestions = true
         };
@@ -196,31 +196,39 @@ namespace Makaretu.Dns
             var request = e.Message;
 
             if (log.IsDebugEnabled)
-                log.Debug($"got query for {request.Questions[0].Name} {request.Questions[0].Type}");
-            var response = NameServer.ResolveAsync(request).Result;
-            if (response.Status == MessageStatus.NoError)
             {
-                // Many bonjour browsers don't like DNS-SD response
-                // with additional records.
-                if (response.Answers.Any(a => a.Name == ServiceName))
-                {
-                    response.AdditionalRecords.Clear();
-                }
-
-                if (AnswersContainsAdditionalRecords)
-                {
-                    response.Answers.AddRange(response.AdditionalRecords);
-                    response.AdditionalRecords.Clear();
-                }
-
-                Mdns.SendAnswer(response);
-                if (log.IsDebugEnabled)
-                    log.Debug($"sent answer {response.Answers[0]}");
-                //Console.WriteLine($"Response time {(DateTime.Now - request.CreationTime).TotalMilliseconds}ms");
+                log.Debug($"got query from: {e.RemoteEndPoint.Address},  for {request.Questions[0].Name} {request.Questions[0].Type}");
             }
+
+            var response = NameServer.ResolveAsync(request).Result;
+
+            if (response.Status != MessageStatus.NoError)
+            {
+                return;
+            }
+
+            if (AnswersContainsAdditionalRecords)
+            {
+                response.Answers.AddRange(response.AdditionalRecords);
+            }
+
+            // Many bonjour browsers don't like DNS-SD response
+            // with additional records.
+            if (response.Answers.Any(a => a.Name == ServiceName))
+            {
+                response.AdditionalRecords.Clear();
+            }
+
+            Mdns.SendAnswer(response);
+
+            if (log.IsDebugEnabled)
+            {
+                log.Debug($"sent answer {response.Answers[0]}");
+            }
+            //Console.WriteLine($"Response time {(DateTime.Now - request.CreationTime).TotalMilliseconds}ms");
         }
 
-#region IDisposable Support
+        #region IDisposable Support
 
         /// <inheritdoc />
         protected virtual void Dispose(bool disposing)
@@ -245,7 +253,7 @@ namespace Makaretu.Dns
         {
             Dispose(true);
         }
-#endregion
-    }
 
+        #endregion
+    }
 }

--- a/test/ServiceProfileTest.cs
+++ b/test/ServiceProfileTest.cs
@@ -1,17 +1,10 @@
-﻿using Makaretu.Dns;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Linq;
 using System.Net;
-using System.Net.NetworkInformation;
-using System.Net.Sockets;
-using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Makaretu.Dns
 {
-    
     [TestClass]
     public class ServiveProfileTest
     {
@@ -25,7 +18,7 @@ namespace Makaretu.Dns
         [TestMethod]
         public void QualifiedNames()
         {
-            var service = new ServiceProfile("x", "_sdtest._udp", 1024, new [] { IPAddress.Loopback });
+            var service = new ServiceProfile("x", "_sdtest._udp", 1024, new[] { IPAddress.Loopback });
 
             Assert.AreEqual("_sdtest._udp.local", service.QualifiedServiceName);
             Assert.AreEqual("x._sdtest._udp.local", service.FullyQualifiedName);
@@ -67,7 +60,7 @@ namespace Makaretu.Dns
         {
             var service = new ServiceProfile("x", "_sdtest._udp", 1024);
             var txt = service.Resources.OfType<TXTRecord>().First();
-            txt.Strings.AddRange(new [] { "a=1", "b=2" });
+            txt.Strings.AddRange(new[] { "a=1", "b=2" });
             CollectionAssert.Contains(txt.Strings, "txtvers=1");
             CollectionAssert.Contains(txt.Strings, "a=1");
             CollectionAssert.Contains(txt.Strings, "b=2");


### PR DESCRIPTION
- fixed AnswersContainsAdditionalRecords functionality 

- fixed using MulticastService with multiple NICs
Added by 1 sender for each NIC. This will allow sending a message directly by specific NIC instead of using system-defined routing.
Adjusted receiver to join a multicast group for specific NIC. This allows receiving messages from all NICs, but not only from "default". (Replacing [PR - 24](https://github.com/richardschneider/net-mdns/pull/24))

- removed exploring networks by times instead used NetworkChange.NetworkAddressChanged
Added using of NetworkChange.NetworkAddressChanged event to get NICs changes. 
-+ added to detect changes from the time when will subscribe on it. Looks like when we subscribing on this event on start will receive only not all changes.

- Added accepting filtering function in MulticastService constructor.
This function, if provided used for bounding MulticastService only to specified NICs, returned by the function. (Replacing  [PR - 32](https://github.com/richardschneider/net-mdns/pull/32))

- Tests are not changed, added "using" instead of try-final blocks

@richardschneider I've tried to do not create breaking changes as much as possible.
But looks like without multi senders, all messages go to "default" nic with system defined route.
Tried a lot of different solutions.
Also, receiver added to the multicast group by local address defined, this also allows receiving messages from all interfaces, because of even using of IPAddress.ANY when joining to the multicast group return messages only from "default" NIC.

PS. By default NIC, I mean, NIC that has lower Number in NICs table :)
