### PR TITLE
MulticastService with multiple NICs

### DIFF
--- a/src/MessageEventArgs.cs
+++ b/src/MessageEventArgs.cs
@@ -1,7 +1,5 @@
-﻿using Makaretu.Dns;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System;
+using System.Net;
 
 namespace Makaretu.Dns
 {
@@ -18,6 +16,14 @@ namespace Makaretu.Dns
         ///   The received message.
         /// </value>
         public Message Message { get; set; }
+
+        /// <summary>
+        ///   The DNS message sender endpoint.
+        /// </summary>
+        /// <value>
+        ///   The endpoint from the message was received.
+        /// </value>
+        public IPEndPoint RemoteEndPoint { get; set; }
     }
 }
 

--- a/src/MulticastService.cs
+++ b/src/MulticastService.cs
@@ -1,16 +1,14 @@
-﻿using Common.Logging;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
-using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Security.Cryptography;
-using System.Text;
+using Common.Logging;
 
 namespace Makaretu.Dns
 {
@@ -28,26 +26,21 @@ namespace Makaretu.Dns
     /// </remarks>
     public class MulticastService : IResolver, IDisposable
     {
-        static readonly ILog log = LogManager.GetLogger(typeof(MulticastService));
-        static readonly IPAddress MulticastAddressIp4 = IPAddress.Parse("224.0.0.251");
-        static readonly IPAddress MulticastAddressIp6 = IPAddress.Parse("FF02::FB");
-        static readonly IPNetwork[] linkLocalNetworks = new IPNetwork[]
-        {
-            IPNetwork.Parse("169.254.0.0/16"),
-            IPNetwork.Parse("fe80::/10")
-        };
-
         const int MulticastPort = 5353;
         // IP header (20 bytes for IPv4; 40 bytes for IPv6) and the UDP header(8 bytes).
         const int packetOverhead = 48;
         const int maxDatagramSize = Message.MaxLength;
 
+        static readonly ILog log = LogManager.GetLogger(typeof(MulticastService));
+        static readonly IPAddress MulticastAddressIp4 = IPAddress.Parse("224.0.0.251");
+        static readonly IPAddress MulticastAddressIp6 = IPAddress.Parse("FF02::FB");
+        static readonly IPNetwork[] LinkLocalNetworks = new[] { IPNetwork.Parse("169.254.0.0/16"), IPNetwork.Parse("fe80::/10") };
+        static readonly IPEndPoint MdnsEndpoint = new IPEndPoint(MulticastUdpListener.IP6 ? MulticastAddressIp6 : MulticastAddressIp4, MulticastPort);
+
         CancellationTokenSource serviceCancellation;
-        CancellationTokenSource listenerCancellation;
 
         List<NetworkInterface> knownNics = new List<NetworkInterface>();
-        readonly bool ip6;
-        IPEndPoint mdnsEndpoint;
+
         int maxPacketSize;
 
         /// <summary>
@@ -61,7 +54,17 @@ namespace Makaretu.Dns
         ///   This is used to avoid floding of responses as per
         ///   <see href="https://github.com/richardschneider/net-mdns/issues/18"/>
         /// </remarks>
-        ConcurrentDictionary<string, DateTime> sentMessages = new ConcurrentDictionary<string, DateTime>();
+        ConcurrentDictionary<long, DateTime> sentMessages = new ConcurrentDictionary<long, DateTime>();
+
+        /// <summary>
+        ///   The multicast listener.
+        /// </summary>
+        MulticastUdpListener listener;
+
+        /// <summary>
+        ///   Function used for listening filtered network interfaces.
+        /// </summary>
+        Func<IEnumerable<NetworkInterface>, IEnumerable<NetworkInterface>> networkInterfacesFilter;
 
         /// <summary>
         ///   Set the default TTLs.
@@ -76,16 +79,7 @@ namespace Makaretu.Dns
         }
 
         /// <summary>
-        ///   The multicast sender.
-        /// </summary>
-        /// <remarks>
-        ///   Always use socketLock to gain access.
-        /// </remarks>
-        UdpClient sender;
-        readonly Object senderLock = new object();
-
-        /// <summary>
-        ///   Raised when any link-local MDNS service sends a query.
+        ///   Raised when any local MDNS service sends a query.
         /// </summary>
         /// <value>
         ///   Contains the query <see cref="Message"/>.
@@ -121,18 +115,12 @@ namespace Makaretu.Dns
         /// <summary>
         ///   Create a new instance of the <see cref="MulticastService"/> class.
         /// </summary>
-        public MulticastService()
+        /// <param name="filter">
+        ///   Multicast listener will be bound to result of filtering function.
+        /// </param>
+        public MulticastService(Func<IEnumerable<NetworkInterface>, IEnumerable<NetworkInterface>> filter = null)
         {
-            if (Socket.OSSupportsIPv4)
-                ip6 = false;
-            else if (Socket.OSSupportsIPv6)
-                ip6 = true;
-            else
-                throw new InvalidOperationException("No OS support for IPv4 nor IPv6");
-
-            mdnsEndpoint = new IPEndPoint(
-                ip6 ? MulticastAddressIp6 : MulticastAddressIp4, 
-                MulticastPort);
+            networkInterfacesFilter = filter;
         }
 
         /// <summary>
@@ -146,6 +134,7 @@ namespace Makaretu.Dns
         ///   new network interfaces. 
         /// </remarks>
         /// <seealso cref="NetworkInterfaceDiscovered"/>
+        [Obsolete("This property is deprecated and will be removed in nearest future. Using timer removed with obsording of NetworkChange.NetworkAddressChanged event.", false)]
         public TimeSpan NetworkInterfaceDiscoveryInterval { get; set; } = TimeSpan.FromMinutes(2);
 
         /// <summary>
@@ -205,10 +194,10 @@ namespace Makaretu.Dns
         {
             serviceCancellation = new CancellationTokenSource();
             maxPacketSize = maxDatagramSize - packetOverhead;
+
             knownNics.Clear();
 
-            // Start a task to find the network interfaces.
-            PollNetworkInterfaces();
+            FindNetworkInterfaces();
         }
 
         /// <summary>
@@ -224,104 +213,71 @@ namespace Makaretu.Dns
             AnswerReceived = null;
             NetworkInterfaceDiscovered = null;
 
+            // Stop current UDP listener
+            listener?.Dispose();
+            listener = null;
+
             // Stop any long runnings tasks.
             using (var sc = serviceCancellation)
             {
                 serviceCancellation = null;
                 sc?.Cancel();
             }
-            using (var lc = listenerCancellation)
-            {
-                listenerCancellation = null;
-                lc?.Cancel();
-            }
-
-            if (sender != null)
-            {
-                sender.Dispose();
-                sender = null;
-            }
         }
 
-        async void PollNetworkInterfaces()
-        {
-            var cancel = serviceCancellation.Token;
-            try
-            {
-                while (!cancel.IsCancellationRequested)
-                {
-                    FindNetworkInterfaces();
-                    await Task.Delay(NetworkInterfaceDiscoveryInterval, cancel);
-                }
-            }
-            catch (TaskCanceledException)
-            {
-                //  eat it
-            }
-            catch (Exception e)
-            {
-                log.Error(e);
-                // eat it.
-            }
-        }
+        void OnNetworkAddressChanged(object sender, EventArgs e) => FindNetworkInterfaces();
 
         void FindNetworkInterfaces()
         {
             var currentNics = GetNetworkInterfaces().ToList();
+
             var newNics = new List<NetworkInterface>();
             var oldNics = new List<NetworkInterface>();
 
-            lock (senderLock)
+            foreach (var nic in knownNics.Where(k => !currentNics.Any(n => k.Id == n.Id)))
             {
-                foreach (var nic in knownNics.Where(k => !currentNics.Any(n => k.Id == n.Id)))
+                oldNics.Add(nic);
+
+                if (log.IsDebugEnabled)
                 {
-                    oldNics.Add(nic);
-                    if (log.IsDebugEnabled)
-                    {
-                        log.Debug($"Removed nic '{nic.Name}'.");
-                    }
-                }
-                foreach (var nic in currentNics.Where(nic => !knownNics.Any(k => k.Id == nic.Id)))
-                {
-                    newNics.Add(nic);
-                    if (log.IsDebugEnabled)
-                    {
-                        log.Debug($"Found nic '{nic.Name}'.");
-                    }
+                    log.Debug($"Removed nic '{nic.Name}'.");
                 }
             }
+
+            foreach (var nic in currentNics.Where(nic => !knownNics.Any(k => k.Id == nic.Id)))
+            {
+                newNics.Add(nic);
+
+                if (log.IsDebugEnabled)
+                {
+                    log.Debug($"Found nic '{nic.Name}'.");
+                }
+            }
+
             knownNics = currentNics;
 
-            // If any NIC change, then get new sockets.
-            if (newNics.Any() || oldNics.Any())
-            {
-                // Recreate the sender
-                if (sender != null)
-                {
-                    sender.Dispose();
-                }
-                sender = new UdpClient(mdnsEndpoint.AddressFamily);
-                sender.JoinMulticastGroup(mdnsEndpoint.Address);
-                sender.MulticastLoopback = true;
-
-                // Start a task to listen for MDNS messages.
-                Listener();
-            }
+            listener?.Dispose();
+            listener = new MulticastUdpListener(MdnsEndpoint, networkInterfacesFilter?.Invoke(knownNics) ?? knownNics);
+            listener.ListenAsync(OnDnsMessage);
 
             // Tell others.
             if (newNics.Any())
-            { 
+            {
                 NetworkInterfaceDiscovered?.Invoke(this, new NetworkInterfaceEventArgs
                 {
                     NetworkInterfaces = newNics
                 });
             }
+
+            NetworkChange.NetworkAddressChanged -= OnNetworkAddressChanged;
+            NetworkChange.NetworkAddressChanged += OnNetworkAddressChanged;
         }
 
         /// <inheritdoc />
         public Task<Message> ResolveAsync(Message request, CancellationToken cancel = default(CancellationToken))
         {
             var tsc = new TaskCompletionSource<Message>();
+
             void checkResponse(object s, MessageEventArgs e)
             {
                 var response = e.Message;
@@ -446,7 +402,7 @@ namespace Makaretu.Dns
             Send(answer, checkDuplicate);
         }
 
-        void Send(Message msg, bool checkDuplicate)
+        void Send(Message msg, bool checkDuplicate = true)
         {
             var packet = msg.ToByteArray();
             if (packet.Length > maxPacketSize)
@@ -454,76 +410,59 @@ namespace Makaretu.Dns
                 throw new ArgumentOutOfRangeException($"Exceeds max packet size of {maxPacketSize}.");
             }
 
-            // Get the hash of the packet.  MD5 is okay because
-            // the hash is not used for security.
-            string hash;
-            using (var md5 = MD5.Create())
+            if (checkDuplicate)
             {
-                var bytes = md5.ComputeHash(packet);
-                // TODO: there must be a more efficient way.
-                var s = new StringBuilder();
-                for (int i = 0; i < bytes.Length; i++)
+                // Get the hash of the packet.
+                var hash = GetHashCode(packet);
+
+                // Prune the sent messages.  Anything older than a second ago is removed.
+                var dead = DateTime.Now.AddSeconds(-1);
+
+                foreach (var notrecent in sentMessages.Where(x => x.Value < dead))
                 {
-                    s.Append(bytes[i].ToString("x2"));
+                    sentMessages.TryRemove(notrecent.Key, out _);
                 }
-                hash = s.ToString();
+
+                // If messsage was recently sent, then do not send again.
+                if (sentMessages.ContainsKey(hash))
+                {
+                    return;
+                }
+
+                sentMessages.AddOrUpdate(hash, DateTime.Now, (key, value) => value);
             }
 
-            // Prune the sent messages.  Anything older than a second ago
-            // is removed.
-            var now = DateTime.Now;
-            var dead = now.AddSeconds(-1);
-            foreach (var notrecent in sentMessages.Where(x => x.Value < dead))
-            {
-                sentMessages.TryRemove(notrecent.Key, out DateTime _);
-            }
-
-            // If messsage was recently sent, then do not send again.
-            if (checkDuplicate && sentMessages.ContainsKey(hash))
-            {
-                return;
-            }
-
-            lock (senderLock)
-            {
-                if (sender == null)
-                    throw new InvalidOperationException("MDNS is not started");
-                sender.SendAsync(packet, packet.Length, mdnsEndpoint).Wait();
-            }
-
-            sentMessages.AddOrUpdate(hash, DateTime.Now, (key, value) => value);
+            listener.SendAsync(packet);
         }
 
         /// <summary>
-        ///   Called by the listener when a DNS message is received.
-        /// </summary>
-        /// <param name="datagram">
-        ///   The received message.
-        /// </param>
-        /// <param name="length">
-        ///   The length of the messages.
-        /// </param>
-        /// <remarks>
-        ///   Decodes the <paramref name="datagram"/> and then raises
-        ///   either the <see cref="QueryReceived"/> or <see cref="AnswerReceived"/> event.
-        ///   <para>
-        ///   Multicast DNS messages received with an OPCODE or RCODE other than zero 
-        ///   are silently ignored.
-        ///   </para>
+        ///   Called by the listener when a DNS message is received.	
+        /// </summary>	
+        /// <param name="result">	
+        ///   The received message <see cref="UdpReceiveResult"/>.	
+        /// </param>	
+        /// <remarks>	
+        ///   Decodes the <paramref name="result"/> and then raises	
+        ///   either the <see cref="QueryReceived"/> or <see cref="AnswerReceived"/> event.	
+        ///   <para>	
+        ///   Multicast DNS messages received with an OPCODE or RCODE other than zero 	
+        ///   are silently ignored.	
+        ///   </para>	
         /// </remarks>
-        void OnDnsMessage(byte[] datagram, int length)
+        void OnDnsMessage(UdpReceiveResult result)
         {
             var msg = new Message();
 
             try
             {
-                msg.Read(datagram, 0, length);
+                msg.Read(result.Buffer, 0, result.Buffer.Length);
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                log.Warn("Received malformed message", e);
+                log.Warn("Received malformed message", ex);
                 return; // eat the exception
             }
+
             if (msg.Opcode != MessageOperation.Query || msg.Status != MessageStatus.NoError)
             {
                 return;
@@ -534,77 +473,31 @@ namespace Makaretu.Dns
             {
                 if (msg.IsQuery && msg.Questions.Count > 0)
                 {
-                    QueryReceived?.Invoke(this, new MessageEventArgs { Message = msg });
+                    QueryReceived?.Invoke(this, new MessageEventArgs { Message = msg, RemoteEndPoint = result.RemoteEndPoint });
                 }
                 else if (msg.IsResponse && msg.Answers.Count > 0)
                 {
-                    AnswerReceived?.Invoke(this, new MessageEventArgs { Message = msg });
+                    AnswerReceived?.Invoke(this, new MessageEventArgs { Message = msg, RemoteEndPoint = result.RemoteEndPoint });
                 }
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                log.Error("Receive handler failed", e);
+                log.Error("Receive handler failed", ex);
                 // eat the exception
             }
         }
 
         /// <summary>
-        ///   Listens for DNS messages.
+        /// Get the hash of the packet.
         /// </summary>
-        /// <remarks>
-        ///   A background task to receive DNS messages from this and other MDNS services.  It is
-        ///   cancelled via <see cref="Stop"/>.  All messages are forwarded to <see cref="OnDnsMessage"/>.
-        /// </remarks>
-        async void Listener()
+        /// <param name="source">UDP packet for hashing.</param>
+        /// <returns></returns>
+        long GetHashCode(byte[] source)
         {
-            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-
-            // Stop the previous listener.
-            if (listenerCancellation != null)
+            // MD5 is okay because the hash is not used for security.
+            using (var md5 = MD5.Create())
             {
-                listenerCancellation.Cancel();
-            }
-
-            listenerCancellation = new CancellationTokenSource();
-            UdpClient receiver = new UdpClient(mdnsEndpoint.AddressFamily);
-            if (isWindows)
-            {
-                receiver.ExclusiveAddressUse = false;
-            }
-            receiver.Client.SetSocketOption(
-                SocketOptionLevel.Socket, 
-                SocketOptionName.ReuseAddress,
-                true);
-            if (isWindows)
-            {
-                receiver.ExclusiveAddressUse = false;
-            }
-            var endpoint = new IPEndPoint(ip6 ? IPAddress.IPv6Any : IPAddress.Any, MulticastPort);
-            receiver.Client.Bind(endpoint);
-            receiver.JoinMulticastGroup(mdnsEndpoint.Address);
-
-            var cancel = listenerCancellation.Token;
-            cancel.Register(() => receiver.Dispose());
-            try
-            {
-                while (!cancel.IsCancellationRequested)
-                {
-                    var result = await receiver.ReceiveAsync();
-                    OnDnsMessage(result.Buffer, result.Buffer.Length);
-                }
-            }
-            catch (Exception e)
-            {
-                if (!cancel.IsCancellationRequested)
-                    log.Error("Listener failed", e);
-                // eat the exception
-            }
-
-            receiver.Dispose();
-            if (listenerCancellation != null)
-            {
-                listenerCancellation.Dispose();
-                listenerCancellation = null;
+                return BitConverter.ToInt64(md5.ComputeHash(source), 0);
             }
         }
 
@@ -626,6 +519,5 @@ namespace Makaretu.Dns
         }
 
         #endregion
-
     }
 }

--- a/src/MulticastUdpListener.cs
+++ b/src/MulticastUdpListener.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+namespace Makaretu.Dns
+{
+    class MulticastUdpListener : IDisposable
+    {
+        public static readonly bool IP6;
+
+        private readonly IPEndPoint multicastEndpoint;
+
+        UdpClient receiver;
+        ConcurrentDictionary<IPAddress, UdpClient> senders = new ConcurrentDictionary<IPAddress, UdpClient>();
+
+        static MulticastUdpListener()
+        {
+            if (Socket.OSSupportsIPv4)
+                IP6 = false;
+            else if (Socket.OSSupportsIPv6)
+                IP6 = true;
+            else
+                throw new InvalidOperationException("No OS support for IPv4 nor IPv6");
+        }
+
+        public MulticastUdpListener(IPEndPoint multicastEndpoint, IEnumerable<NetworkInterface> nics)
+        {
+            this.multicastEndpoint = multicastEndpoint;
+
+            receiver = new UdpClient(multicastEndpoint.AddressFamily);
+
+            receiver.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+            receiver.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ExclusiveAddressUse, false);
+
+            receiver.Client.Bind(new IPEndPoint(IP6 ? IPAddress.IPv6Any : IPAddress.Any, multicastEndpoint.Port));
+
+            foreach (var address in nics.SelectMany(GetNetworkInterfaceLocalAddresses))
+            {
+                try
+                {
+                    receiver.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, new MulticastOption(multicastEndpoint.Address, address));
+
+                    var sender = new UdpClient(multicastEndpoint.AddressFamily);
+
+                    sender.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                    sender.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ExclusiveAddressUse, false);
+
+                    sender.Client.Bind(new IPEndPoint(address, multicastEndpoint.Port));
+
+                    sender.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, new MulticastOption(multicastEndpoint.Address));
+                    sender.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastLoopback, true);
+
+                    senders.TryAdd(address, sender);
+                }
+                catch (SocketException ex) when (ex.SocketErrorCode == SocketError.AddressNotAvailable)
+                {
+                    // VPN NetworkInterfaces
+                }
+            }
+        }
+
+        public void SendAsync(byte[] message)
+        {
+            senders.ToList().ForEach(x => x.Value.SendAsync(message, message.Length, multicastEndpoint));
+        }
+
+        public void ListenAsync(Action<UdpReceiveResult> callback)
+        {
+            Task.Run(async () =>
+            {
+                try
+                {
+                    var result = await receiver.ReceiveAsync().ConfigureAwait(false);
+
+                    ListenAsync(callback);
+
+                    new Task(() => callback(result)).Start();
+                }
+                catch (ObjectDisposedException)
+                {
+                    return;
+                }
+            });
+        }
+
+        IEnumerable<IPAddress> GetNetworkInterfaceLocalAddresses(NetworkInterface nic)
+        {
+            return nic.GetIPProperties().UnicastAddresses
+                .Select(x => x.Address)
+                .Where(x => x.AddressFamily == (IP6 ? AddressFamily.InterNetworkV6 : AddressFamily.InterNetwork));
+        }
+
+        #region IDisposable Support
+
+        private bool disposedValue = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    receiver?.Dispose();
+
+                    foreach (var address in senders.Keys)
+                    {
+                        if (senders.TryRemove(address, out var sender))
+                        {
+                            sender.Dispose();
+                        }
+                    }
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        ~MulticastUdpListener()
+        {
+            Dispose(false);
+        }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        #endregion
+    }
+}

--- a/src/ServiceDiscovery.cs
+++ b/src/ServiceDiscovery.cs
@@ -1,9 +1,8 @@
-﻿using Common.Logging;
-using Makaretu.Dns.Resolving;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
+using Common.Logging;
+using Makaretu.Dns.Resolving;
 
 namespace Makaretu.Dns
 {
@@ -80,7 +79,8 @@ namespace Makaretu.Dns
         /// <value>
         ///   Is used to answer questions.
         /// </value>
-        public NameServer NameServer { get; } = new NameServer {
+        public NameServer NameServer { get; } = new NameServer
+        {
             Catalog = new Catalog(),
             AnswerAllQuestions = true
         };
@@ -196,31 +196,39 @@ namespace Makaretu.Dns
             var request = e.Message;
 
             if (log.IsDebugEnabled)
-                log.Debug($"got query for {request.Questions[0].Name} {request.Questions[0].Type}");
-            var response = NameServer.ResolveAsync(request).Result;
-            if (response.Status == MessageStatus.NoError)
             {
-                // Many bonjour browsers don't like DNS-SD response
-                // with additional records.
-                if (response.Answers.Any(a => a.Name == ServiceName))
-                {
-                    response.AdditionalRecords.Clear();
-                }
-
-                if (AnswersContainsAdditionalRecords)
-                {
-                    response.Answers.AddRange(response.AdditionalRecords);
-                    response.AdditionalRecords.Clear();
-                }
-
-                Mdns.SendAnswer(response);
-                if (log.IsDebugEnabled)
-                    log.Debug($"sent answer {response.Answers[0]}");
-                //Console.WriteLine($"Response time {(DateTime.Now - request.CreationTime).TotalMilliseconds}ms");
+                log.Debug($"got query from: {e.RemoteEndPoint.Address},  for {request.Questions[0].Name} {request.Questions[0].Type}");
             }
+
+            var response = NameServer.ResolveAsync(request).Result;
+
+            if (response.Status != MessageStatus.NoError)
+            {
+                return;
+            }
+
+            if (AnswersContainsAdditionalRecords)
+            {
+                response.Answers.AddRange(response.AdditionalRecords);
+            }
+
+            // Many bonjour browsers don't like DNS-SD response
+            // with additional records.
+            if (response.Answers.Any(a => a.Name == ServiceName))
+            {
+                response.AdditionalRecords.Clear();
+            }
+
+            Mdns.SendAnswer(response);
+
+            if (log.IsDebugEnabled)
+            {
+                log.Debug($"sent answer {response.Answers[0]}");
+            }
+            //Console.WriteLine($"Response time {(DateTime.Now - request.CreationTime).TotalMilliseconds}ms");
         }
 
-#region IDisposable Support
+        #region IDisposable Support
 
         /// <inheritdoc />
         protected virtual void Dispose(bool disposing)
@@ -245,7 +253,7 @@ namespace Makaretu.Dns
         {
             Dispose(true);
         }
-#endregion
-    }
 
+        #endregion
+    }
 }


### PR DESCRIPTION
- fixed AnswersContainsAdditionalRecords functionality 

- fixed using MulticastService with multiple NICs
Added by 1 sender for each NIC. This will allow sending a message directly by specific NIC instead of using system-defined routing.
Adjusted receiver to join a multicast group for specific NIC. This allows receiving messages from all NICs, but not only from "default". (Replacing [PR - 24](https://github.com/richardschneider/net-mdns/pull/24))

- removed exploring networks by times instead used NetworkChange.NetworkAddressChanged
Added using of NetworkChange.NetworkAddressChanged event to get NICs changes. 
-+ added to detect changes from the time when will subscribe on it. Looks like when we subscribing on this event on start will receive only not all changes.

- Added accepting filtering function in MulticastService constructor.
This function, if provided used for bounding MulticastService only to specified NICs, returned by the function. (Replacing  [PR - 32](https://github.com/richardschneider/net-mdns/pull/32))

- Tests are not changed, added "using" instead of try-final blocks

@richardschneider I've tried to do not create breaking changes as much as possible.
But looks like without multi senders, all messages go to "default" nic with system defined route.
Tried a lot of different solutions.
Also, receiver added to the multicast group by local address defined, this also allows receiving messages from all interfaces, because of even using of IPAddress.ANY when joining to the multicast group return messages only from "default" NIC.

PS. By default NIC, I mean, NIC that has lower Number in NICs table :)
