### PR TITLE
Fix missing underscore on service name

### DIFF
--- a/Spike/Program.cs
+++ b/Spike/Program.cs
@@ -54,7 +54,7 @@ namespace Spike
             var sd = new ServiceDiscovery(mdns);
             sd.Advertise(new ServiceProfile("x1", "_xservice._tcp", 5011));
             sd.Advertise(new ServiceProfile("x2", "_xservice._tcp", 666));
-            var z1 = new ServiceProfile("z1", "_zservice.udp", 5012);
+            var z1 = new ServiceProfile("z1", "_zservice._udp", 5012);
             z1.AddProperty("foo", "bar");
             sd.Advertise(z1);
 


### PR DESCRIPTION
This PR fixes a mistake on the sample code for service advertisement.