### PR TITLE
detect network change on Mac Catalina

### DIFF
--- a/src/MulticastService.cs
+++ b/src/MulticastService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
@@ -330,8 +331,17 @@ namespace Makaretu.Dns
                 // (wifi off, but NIC is not disabled, wifi - on, NIC was not changed 
                 // so no event). Rebinding fixes this.
                 //
+                // Do magic only on Windows.
+#if NET461
                 NetworkChange.NetworkAddressChanged -= OnNetworkAddressChanged;
                 NetworkChange.NetworkAddressChanged += OnNetworkAddressChanged;
+#else
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    NetworkChange.NetworkAddressChanged -= OnNetworkAddressChanged;
+                    NetworkChange.NetworkAddressChanged += OnNetworkAddressChanged;
+                }
+#endif
             }
             catch (Exception e)
             {
@@ -673,7 +683,7 @@ namespace Makaretu.Dns
             }
         }
 
-        #region IDisposable Support
+#region IDisposable Support
 
         /// <inheritdoc />
         protected virtual void Dispose(bool disposing)
@@ -690,6 +700,6 @@ namespace Makaretu.Dns
             Dispose(true);
         }
 
-        #endregion
+#endregion
     }
 }

--- a/src/MulticastService.cs
+++ b/src/MulticastService.cs
@@ -333,15 +333,14 @@ namespace Makaretu.Dns
                 //
                 // Do magic only on Windows.
 #if NET461
-                NetworkChange.NetworkAddressChanged -= OnNetworkAddressChanged;
-                NetworkChange.NetworkAddressChanged += OnNetworkAddressChanged;
+                if (Environment.OSVersion.Platform.ToString().StartsWith("Win"))
 #else
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+#endif
                 {
                     NetworkChange.NetworkAddressChanged -= OnNetworkAddressChanged;
                     NetworkChange.NetworkAddressChanged += OnNetworkAddressChanged;
                 }
-#endif
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Only do magic from @eshvatskyi on Windows.  Removing/Adding event handler causes
infinitive recursion on Catalina.  See #87