### PR TITLE
Dispose UdpClient instances when disposing MulticastService

### DIFF
--- a/src/MulticastService.cs
+++ b/src/MulticastService.cs
@@ -268,9 +268,6 @@ namespace Makaretu.Dns
             AnswerReceived = null;
             NetworkInterfaceDiscovered = null;
 
-            unicastClientIp4?.Dispose();
-            unicastClientIp6?.Dispose();
-
             // Stop current UDP listener
             client?.Dispose();
             client = null;
@@ -692,6 +689,8 @@ namespace Makaretu.Dns
         {
             if (disposing)
             {
+                unicastClientIp4?.Dispose();
+                unicastClientIp6?.Dispose();
                 Stop();
             }
         }

--- a/src/MulticastService.cs
+++ b/src/MulticastService.cs
@@ -268,6 +268,9 @@ namespace Makaretu.Dns
             AnswerReceived = null;
             NetworkInterfaceDiscovered = null;
 
+            unicastClientIp4?.Dispose();
+            unicastClientIp6?.Dispose();
+
             // Stop current UDP listener
             client?.Dispose();
             client = null;


### PR DESCRIPTION
Since UdpClient implements IDisposable, and unicastClientIp4 and unicastClientIp6 are members of the MulticastService class, these instances must be disposed when disposing the MulticastService instance.

See issue [93](https://github.com/richardschneider/net-mdns/issues/93)